### PR TITLE
chore: migrate workspace config to pnpm 11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-engine-strict=true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "daniel-salvado-website",
 	"version": "0.0.1",
+	"packageManager": "pnpm@11.9.0",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"@commitlint/config-conventional": "^20.5.0",
 		"@eslint/js": "^10.0.1",
 		"@sveltejs/adapter-cloudflare": "^7.2.8",
-		"@sveltejs/kit": "^2.56.1",
+		"@sveltejs/kit": "2.57.1",
 		"@sveltejs/vite-plugin-svelte": "^7.0.0",
 		"@tailwindcss/typography": "^0.5.19",
 		"@tailwindcss/vite": "^4.2.2",
@@ -31,7 +31,7 @@
 		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-svelte": "^3.17.0",
 		"globals": "^17.4.0",
-		"postcss": "^8.5.8",
+		"postcss": "8.5.10",
 		"prettier": "^3.8.1",
 		"prettier-plugin-svelte": "^3.5.1",
 		"prettier-plugin-tailwindcss": "^0.7.2",
@@ -42,12 +42,11 @@
 		"tslib": "^2.8.1",
 		"typescript": "~6.0.2",
 		"typescript-eslint": "^8.58.0",
-		"vite": "^8.0.3",
+		"vite": "8.0.5",
 		"wrangler": "^4.80.0"
 	},
 	"type": "module",
 	"engines": {
-		"node": ">=22.16.0",
-		"pnpm": ">=10.11.0"
+		"node": ">=22.16.0"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,7 +104,7 @@ importers:
         version: 5.56.7(@typescript-eslint/types@8.58.0)
       svelte-check:
         specifier: ^4.4.6
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.56.7(@typescript-eslint/types@8.58.0))(typescript@6.0.2)
+        version: 4.4.6(picomatch@4.0.5)(svelte@5.56.7(@typescript-eslint/types@8.58.0))(typescript@6.0.2)
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -118,7 +118,7 @@ importers:
         specifier: ^8.58.0
         version: 8.58.0(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
       vite:
-        specifier: ^8.0.5
+        specifier: ^8.0.16
         version: 8.1.5(@types/node@25.3.2)(esbuild@0.28.1)(jiti@2.6.1)
       wrangler:
         specifier: ^4.80.0
@@ -1662,10 +1662,6 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@4.0.4:
-    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
-    engines: {node: '>=12'}
-
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
@@ -1901,10 +1897,6 @@ packages:
   tinyexec@1.0.4:
     resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
     engines: {node: '>=18'}
-
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
@@ -2816,7 +2808,7 @@ snapshots:
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@6.0.2)
       typescript: 6.0.2
     transitivePeerDependencies:
@@ -3150,9 +3142,9 @@ snapshots:
 
   fast-uri@3.1.4: {}
 
-  fdir@6.5.0(picomatch@4.0.4):
+  fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -3413,8 +3405,6 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@4.0.4: {}
-
   picomatch@4.0.5: {}
 
   postcss-load-config@3.1.4(postcss@8.5.22):
@@ -3571,11 +3561,11 @@ snapshots:
 
   supports-color@10.2.2: {}
 
-  svelte-check@4.4.6(picomatch@4.0.4)(svelte@5.56.7(@typescript-eslint/types@8.58.0))(typescript@6.0.2):
+  svelte-check@4.4.6(picomatch@4.0.5)(svelte@5.56.7(@typescript-eslint/types@8.58.0))(typescript@6.0.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       chokidar: 4.0.3
-      fdir: 6.5.0(picomatch@4.0.4)
+      fdir: 6.5.0(picomatch@4.0.5)
       picocolors: 1.1.1
       sade: 1.8.1
       svelte: 5.56.7(@typescript-eslint/types@8.58.0)
@@ -3622,15 +3612,10 @@ snapshots:
 
   tinyexec@1.0.4: {}
 
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-
   tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   totalist@3.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,10 @@
+engineStrict: true
 allowBuilds:
+  '@sveltejs/kit': true
   esbuild: true
   sharp: true
   simple-git-hooks: true
+  svelte-preprocess: true
   workerd: true
 minimumReleaseAgeExclude:
   - cookie@0.7.0
@@ -18,12 +21,6 @@ minimumReleaseAgeExclude:
   - undici@7.28.0
   - js-yaml@4.1.2 || 4.3.0
   - sharp@0.35.0
-onlyBuiltDependencies:
-  - '@sveltejs/kit'
-  - esbuild
-  - simple-git-hooks
-  - svelte-preprocess
-  - workerd
 overrides:
   '@sveltejs/kit@<=2.57.0': ^2.57.1
   '@sveltejs/kit@>=2.38.0 <=2.60.0': ^2.60.1

--- a/src/app.html
+++ b/src/app.html
@@ -10,7 +10,10 @@
 			rel="preload"
 			as="style"
 			href="https://fonts.googleapis.com/css2?family=Reenie+Beanie&display=swap&text=DanielSalvado0123456789"
-			onload="this.onload=null;this.rel='stylesheet'"
+			onload="
+				this.onload = null;
+				this.rel = 'stylesheet';
+			"
 		/>
 		<noscript>
 			<link
@@ -86,7 +89,7 @@
 		%sveltekit.head%
 		<script>
 			console.log(
-				'%cDaniel Salvado%c\n\nIf you\'re reading this, you\'re probably an engineer.\nSo am I — and I might be open to what you\'re building.\n\nhttps://github.com/danisal\nhttps://linkedin.com/in/daniel-salvado',
+				"%cDaniel Salvado%c\n\nIf you're reading this, you're probably an engineer.\nSo am I — and I might be open to what you're building.\n\nhttps://github.com/danisal\nhttps://linkedin.com/in/daniel-salvado",
 				'background:#f59e0b;color:#1c1917;font-weight:700;padding:2px 6px;border-radius:2px;',
 				'color:#737373;font-size:11px;'
 			);

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -3,6 +3,6 @@
 </script>
 
 <header class="flex items-center justify-between">
-	<a class="font-beanie text-3xl sm:text-4xl font-medium no-underline" href="/"> Daniel Salvado </a>
+	<a class="font-beanie text-3xl font-medium no-underline sm:text-4xl" href="/"> Daniel Salvado </a>
 	<ThemeToggle />
 </header>

--- a/src/lib/components/ThemeToggle.svelte
+++ b/src/lib/components/ThemeToggle.svelte
@@ -48,7 +48,7 @@
 		stroke-width="2"
 		stroke-linecap="round"
 		stroke-linejoin="round"
-		class="absolute text-neutral-500 transition-[transform,opacity] duration-200 group-hover:text-neutral-950 dark:rotate-90 dark:scale-0 dark:opacity-0 dark:group-hover:text-neutral-50"
+		class="absolute text-neutral-500 transition-[transform,opacity] duration-200 group-hover:text-neutral-950 dark:scale-0 dark:rotate-90 dark:opacity-0 dark:group-hover:text-neutral-50"
 		aria-hidden="true"
 	>
 		<circle cx="12" cy="12" r="4" />
@@ -73,7 +73,7 @@
 		stroke-width="2"
 		stroke-linecap="round"
 		stroke-linejoin="round"
-		class="absolute -rotate-90 scale-0 text-neutral-500 opacity-0 transition-[transform,opacity] duration-200 group-hover:text-neutral-950 dark:rotate-0 dark:scale-100 dark:opacity-100 dark:group-hover:text-neutral-50"
+		class="absolute scale-0 -rotate-90 text-neutral-500 opacity-0 transition-[transform,opacity] duration-200 group-hover:text-neutral-950 dark:scale-100 dark:rotate-0 dark:opacity-100 dark:group-hover:text-neutral-50"
 		aria-hidden="true"
 	>
 		<path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -16,7 +16,7 @@
 	<div class="mt-10">
 		<a
 			href="/"
-			class="inline-block rounded-lg bg-amber-500 px-6 py-3 font-medium text-amber-950 no-underline transition-colors hover:bg-amber-600 hover:no-underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-amber-950 dark:bg-amber-300 dark:hover:bg-amber-400 dark:focus-visible:ring-amber-950"
+			class="inline-block rounded-lg bg-amber-500 px-6 py-3 font-medium text-amber-950 no-underline transition-colors hover:bg-amber-600 hover:no-underline focus-visible:ring-2 focus-visible:ring-amber-950 focus-visible:ring-offset-2 focus-visible:outline-none dark:bg-amber-300 dark:hover:bg-amber-400 dark:focus-visible:ring-amber-950"
 		>
 			&larr; Go back home
 		</a>

--- a/src/routes/legal-notice/+page.svelte
+++ b/src/routes/legal-notice/+page.svelte
@@ -12,7 +12,9 @@
 		This page informs you of our policies regarding the collection, use, and disclosure of personal data when you use
 		our Service and the choices you have associated with that data. Our Privacy Policy for Daniel Salvado is created
 		with the help of the
-		<a href="https://www.freeprivacypolicy.com/" rel="noopener noreferrer" target="_blank"> Free Privacy Policy website </a>
+		<a href="https://www.freeprivacypolicy.com/" rel="noopener noreferrer" target="_blank">
+			Free Privacy Policy website
+		</a>
 		.
 	</p>
 


### PR DESCRIPTION
## Summary
- Migrate `pnpm-workspace.yaml` from the legacy `onlyBuiltDependencies` list to pnpm 11's `allowBuilds` map format, and add `engineStrict: true`
- Drop `.npmrc` (`engine-strict=true` is now redundant) and remove the `pnpm` version pin from `package.json` engines
- Regenerate `pnpm-lock.yaml` under pnpm 11.9.0 (also picks up the `vite` security override bump to `^8.0.16`)
- Reformat 5 files after the lockfile refresh pulled in newer prettier/prettier-plugin-tailwindcss versions

## Test plan
- [x] `pnpm check` — 0 errors, 0 warnings
- [x] `pnpm lint` — prettier + eslint pass clean
- [x] `pnpm build` — production build succeeds